### PR TITLE
Add standard gitignore to avoid committing build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,53 @@
+# General OS artifacts
+.DS_Store
+Thumbs.db
+
+# Python specific ignores
+__pycache__/
+*.py[cod]
+*$py.class
+.python-version
+.venv/
+venv/
+env/
+.Python
+.pytest_cache/
+.coverage*
+.tox/
+.mypy_cache/
+.nox/
+.eggs/
+*.egg-info/
+
+# Build and distribution directories
+build/
+dist/
+htmlcov/
+site/
+
+# Environment and secrets
+.env
+.env.*
+*.pem
+
+# Logs and databases
+*.log
+*.sqlite3
+*.db
+
+# Node and JavaScript dependencies
+node_modules/
+.pnp/
+yarn-error.log
+npm-debug.log*
+yarn-debug.log*
+
+# IDE and editor folders
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Caches
+.cache/
+.tmp/


### PR DESCRIPTION
## Summary
- add a repository-level .gitignore covering Python, Node, and common editor artifacts
- prevent large cache, build, environment, and log directories from being tracked to speed up commits

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d401181538832a9a50fc8ec38770e6