### PR TITLE
Improve source aggregation and fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# Global ignore rules
+__pycache__/
+*.py[cod]
+*.so
+*.dylib
+*.egg-info/
+*.egg
+build/
+dist/
+.eggs/
+
+# Environment & tooling
+.env
+.env.local
+.venv/
+.venv*/
+*.code-workspace
+.vscode/
+.idea/
+.pytest_cache/
+.coverage*
+htmlcov/
+.mypy_cache/
+
+# OS-generated files
+.DS_Store
+Thumbs.db
+
+# Project-specific outputs
+CostEstimateGenerator/outputs/*
+!CostEstimateGenerator/outputs/.gitignore

--- a/CostEstimateGenerator/.github/workflows/ci.yml
+++ b/CostEstimateGenerator/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    paths:
+      - 'CostEstimateGenerator/**'
+  pull_request:
+    paths:
+      - 'CostEstimateGenerator/**'
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r CostEstimateGenerator/requirements.txt
+          pip install -e CostEstimateGenerator
+      - name: Run tests
+        run: python -m pytest -q
+        working-directory: CostEstimateGenerator

--- a/CostEstimateGenerator/README.md
+++ b/CostEstimateGenerator/README.md
@@ -1,0 +1,93 @@
+# Cost Estimate Generator
+
+The Cost Estimate Generator ingests historical pay-item pricing data, computes
+summary statistics, and updates estimate workbooks and audit CSV files in
+place. The project ships with synthetic sample data that demonstrate the
+expected file layout and allow the pipeline to be exercised end-to-end without
+external services.
+
+## Features
+
+- Reads historical price data from Excel workbooks (sheet-per-item) and from
+  directories of CSV files, aggregating every matching source for a pay item.
+- Computes `DATA_POINTS_USED`, `MEAN_UNIT_PRICE`, `STD_DEV`, `COEF_VAR`, and a
+  confidence score per pay item using the formula
+  `confidence = (1 - exp(-n/30)) * (1 / (1 + cv))`.
+- Updates `Estimate_Draft.xlsx` by inserting a `CONFIDENCE` column immediately
+  after `DATA_POINTS_USED` within the `Estimate` sheet.
+- Updates `Estimate_Audit.csv` by inserting `STD_DEV` and `COEF_VAR` columns
+  after `DATA_POINTS_USED` and populating them for every row.
+- Produces a debug mapping report at `outputs/payitem_mapping_debug.csv` showing
+  how item codes were matched to historical sources.
+- Supports `--dry-run` mode and optional AI assistance that can be disabled
+  via CLI flags or the `DISABLE_OPENAI=1` environment variable.
+
+## Quick start
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # PowerShell: .venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+pip install -e .
+```
+
+Generate fresh sample output files from the text templates:
+
+```bash
+python scripts/prepare_sample_outputs.py
+```
+
+The script copies the CSV audit sample and materialises Excel workbooks from
+`data_sample/Estimate_Draft_template.csv` and
+`data_sample/payitems_workbook.json` into the `outputs/` directory. With those
+files in place, run the pipeline against the samples:
+
+```bash
+python -m costest.cli \
+  --input-payitems data_sample/payitems \
+  --payitems-workbook outputs/PayItems_Audit.xlsx \
+  --estimate-audit-csv outputs/Estimate_Audit.csv \
+  --estimate-xlsx outputs/Estimate_Draft.xlsx
+```
+
+When run without explicit paths the CLI looks for `outputs/PayItems_Audit.xlsx`
+and falls back to the bundled sample workbook or to a `data_in/` directory if
+present. Supply `--mapping-debug-csv` to write the mapping report to a custom
+location.
+
+`DISABLE_OPENAI=1` is respected automatically; set it (or use the
+`--disable-ai` flag) when running offline. If AI assistance is desired, provide
+an API key via the `OPENAI_API_KEY` environment variable or by storing it in
+`API_KEY/API_KEY.txt` and omitting the disable flag.
+
+A convenience wrapper is available:
+
+```bash
+python scripts/run_pipeline.py --help
+```
+
+## Testing
+
+Run the automated test suite with:
+
+```bash
+python -m pytest -q
+```
+
+Continuous integration runs the same command on every push via GitHub Actions.
+
+## Project layout
+
+```
+CostEstimateGenerator/
+├── src/costest/                # Library code
+├── data_sample/                # Synthetic sample inputs
+├── outputs/                    # Target directory for generated outputs
+├── scripts/run_pipeline.py     # CLI wrapper
+├── tests/                      # Pytest-based unit and integration tests
+├── requirements.txt            # Reproducible dependency pins
+└── pyproject.toml              # Packaging metadata
+```
+
+The project is designed to be idempotent: running the pipeline multiple times
+with the same inputs produces consistent outputs.

--- a/CostEstimateGenerator/data_sample/Estimate_Audit.csv
+++ b/CostEstimateGenerator/data_sample/Estimate_Audit.csv
@@ -1,0 +1,5 @@
+ITEM_CODE,DESCRIPTION,UNIT,QUANTITY,DATA_POINTS_USED,MEAN_UNIT_PRICE
+ITEM-001,Concrete placement,CY,100,0,0
+ITEM 002,Asphalt paving,TON,50,0,0
+Item004,Guardrail installation,LF,200,0,0
+ITEM005,Unknown item,EA,10,0,0

--- a/CostEstimateGenerator/data_sample/Estimate_Draft_template.csv
+++ b/CostEstimateGenerator/data_sample/Estimate_Draft_template.csv
@@ -1,0 +1,5 @@
+ITEM_CODE,DESCRIPTION,DATA_POINTS_USED,MEAN_UNIT_PRICE,OTHER_COLUMN
+ITEM-001,Concrete placement,0,0,A
+ITEM 002,Asphalt paving,0,0,B
+Item004,Guardrail installation,0,0,C
+ITEM005,Unknown item,0,0,D

--- a/CostEstimateGenerator/data_sample/payitems/item005_prices.csv
+++ b/CostEstimateGenerator/data_sample/payitems/item005_prices.csv
@@ -1,0 +1,2 @@
+recorded_price,notes
+,no price

--- a/CostEstimateGenerator/data_sample/payitems_workbook.json
+++ b/CostEstimateGenerator/data_sample/payitems_workbook.json
@@ -1,0 +1,26 @@
+{
+  "Item 001 - Concrete": {
+    "columns": ["DATE", "Unit Price", "Vendor"],
+    "rows": [
+      ["2023-01-01", 100.0, "Vendor A"],
+      ["2023-02-01", 110.0, "Vendor B"],
+      ["2023-03-01", 105.0, "Vendor C"]
+    ]
+  },
+  "ITEM002": {
+    "columns": ["PRICE", "Notes"],
+    "rows": [
+      [50.0, "Bid 1"],
+      [55.0, "Bid 2"],
+      [60.0, "Bid 3"]
+    ]
+  },
+  "Item004 History": {
+    "columns": ["DIST_AVG", "STATE_VALUE"],
+    "rows": [
+      [75.0, 80.0],
+      [74.0, null],
+      [82.0, null]
+    ]
+  }
+}

--- a/CostEstimateGenerator/outputs/.gitignore
+++ b/CostEstimateGenerator/outputs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/CostEstimateGenerator/pyproject.toml
+++ b/CostEstimateGenerator/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "costest"
+version = "0.1.0"
+description = "Cost Estimate Generator"
+readme = "README.md"
+authors = [{ name = "Road Tools Automation" }]
+requires-python = ">=3.9"
+dependencies = [
+    "numpy==1.26.4",
+    "pandas==1.5.3",
+    "openpyxl==3.1.2",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/CostEstimateGenerator/requirements.txt
+++ b/CostEstimateGenerator/requirements.txt
@@ -1,0 +1,5 @@
+numpy==1.26.4
+pandas==1.5.3
+openpyxl==3.1.2
+pytest==7.4.4
+python-dotenv==1.0.0

--- a/CostEstimateGenerator/scripts/prepare_sample_outputs.py
+++ b/CostEstimateGenerator/scripts/prepare_sample_outputs.py
@@ -1,0 +1,37 @@
+"""Generate sample output files from the shipped templates."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from costest.sample_data import (
+    DATA_SAMPLE_DIR,
+    create_estimate_workbook_from_template,
+    create_payitems_workbook_from_template,
+)
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    outputs = project_root / "outputs"
+    outputs.mkdir(parents=True, exist_ok=True)
+
+    estimate_template = DATA_SAMPLE_DIR / "Estimate_Draft_template.csv"
+    estimate_dest = outputs / "Estimate_Draft.xlsx"
+    create_estimate_workbook_from_template(estimate_template, estimate_dest)
+
+    payitems_template = DATA_SAMPLE_DIR / "payitems_workbook.json"
+    payitems_dest = outputs / "PayItems_Audit.xlsx"
+    create_payitems_workbook_from_template(payitems_template, payitems_dest)
+
+    audit_src = DATA_SAMPLE_DIR / "Estimate_Audit.csv"
+    audit_dest = outputs / "Estimate_Audit.csv"
+    shutil.copy(audit_src, audit_dest)
+
+    print(f"Wrote sample Estimate_Audit.csv to {audit_dest}")
+    print(f"Wrote sample Estimate_Draft.xlsx to {estimate_dest}")
+    print(f"Wrote sample PayItems_Audit.xlsx to {payitems_dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/CostEstimateGenerator/scripts/run_pipeline.py
+++ b/CostEstimateGenerator/scripts/run_pipeline.py
@@ -1,0 +1,8 @@
+"""Helper script to run the default cost estimate pipeline."""
+from __future__ import annotations
+
+from costest.cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/CostEstimateGenerator/src/costest/__init__.py
+++ b/CostEstimateGenerator/src/costest/__init__.py
@@ -1,0 +1,10 @@
+"""Cost Estimate Generator package."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:  # pragma: no cover - best effort metadata lookup
+    __version__ = version("costest")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]

--- a/CostEstimateGenerator/src/costest/ai_wrapper.py
+++ b/CostEstimateGenerator/src/costest/ai_wrapper.py
@@ -1,0 +1,41 @@
+"""Optional OpenAI helper used for future enhancements."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class AIHelper:
+    """Wrapper that encapsulates access to OpenAI-like APIs."""
+
+    api_key: Optional[str]
+    disabled: bool = False
+
+    def __post_init__(self) -> None:
+        if self.disabled:
+            LOGGER.info("AI assistance disabled via flag or environment.")
+        elif not self.api_key:
+            LOGGER.info("No API key provided; AI assistance inactive.")
+            self.disabled = True
+
+    def summarize(self, item_code: str, stats: Dict[str, Any]) -> Optional[str]:
+        """Return a short AI-generated summary if enabled.
+
+        The current implementation intentionally avoids calling any external
+        services when disabled. It returns ``None`` when AI is unavailable.
+        """
+
+        if self.disabled or not self.api_key:
+            return None
+
+        # Placeholder for future integration. We avoid external calls to keep the
+        # project offline-friendly, but structure the method for extensibility.
+        LOGGER.debug("AI summary requested for %s with stats %s", item_code, stats)
+        return None
+
+
+__all__ = ["AIHelper"]

--- a/CostEstimateGenerator/src/costest/cli.py
+++ b/CostEstimateGenerator/src/costest/cli.py
@@ -1,0 +1,193 @@
+"""Command line interface for the cost estimate generator."""
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import sys
+from typing import Dict, Iterable, List, Optional, Sequence, Set
+
+import pandas as pd
+
+from .ai_wrapper import AIHelper
+from .config import Config, load_config, read_api_key
+from . import io
+from .mapping import MatchResult, PayItemMapper, normalize_key
+from .stats import StatsSummary, compute_summary
+from .writer import update_estimate_audit, update_estimate_draft, write_mapping_debug
+
+LOGGER = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate cost estimate statistics")
+    parser.add_argument("--input-payitems", dest="input_payitems", default=None, help="Directory containing historical CSV files")
+    parser.add_argument("--estimate-audit-csv", dest="estimate_audit_csv", default=None, help="Path to Estimate_Audit.csv")
+    parser.add_argument("--estimate-xlsx", dest="estimate_xlsx", default=None, help="Path to Estimate_Draft.xlsx")
+    parser.add_argument("--payitems-workbook", dest="payitems_workbook", default=None, help="Path to PayItems workbook")
+    parser.add_argument("--mapping-debug-csv", dest="mapping_debug_csv", default=None, help="Path for debug mapping csv")
+    parser.add_argument("--disable-ai", action="store_true", help="Disable OpenAI assistance")
+    parser.add_argument("--api-key-file", dest="api_key_file", default=None, help="File containing API key")
+    parser.add_argument("--dry-run", action="store_true", help="Do not write any files")
+    parser.add_argument("--log-level", default="INFO", help="Logging level (DEBUG, INFO, WARNING, ERROR)")
+    return parser
+
+
+def _find_item_code_column(columns: Iterable[str]) -> Optional[str]:
+    for column in columns:
+        if column and "item" in column.lower() and "code" in column.lower():
+            return column
+    return None
+
+
+def _collect_item_codes(df: pd.DataFrame) -> Set[str]:
+    column = _find_item_code_column(df.columns)
+    if not column:
+        return set()
+    series = df[column].dropna()
+    return {str(value).strip() for value in series if str(value).strip()}
+
+
+def _stats_to_dict(stats: StatsSummary) -> Dict[str, float]:
+    return {
+        "data_points": stats.data_points,
+        "mean": stats.mean,
+        "std_dev": stats.std_dev,
+        "coef_var": stats.coef_var,
+        "confidence": stats.confidence,
+    }
+
+
+def _combine_price_values(results: Sequence[io.PriceSeriesResult]) -> List[float]:
+    values: List[float] = []
+    for result in results:
+        if result.has_values():
+            values.extend(result.values.tolist())
+    return values
+
+
+def _describe_notes(match: MatchResult, results: Sequence[io.PriceSeriesResult]) -> str:
+    if not match.matches:
+        return "No matching historical data"
+    if not any(result.has_values() for result in results):
+        return "No usable prices"
+    direct = any(result.has_values() and not result.used_fallback for result in results)
+    fallback = any(result.has_values() and result.used_fallback for result in results)
+    if direct and fallback:
+        return "Mixed direct and fallback columns"
+    if direct:
+        return "Direct price columns"
+    if fallback:
+        return "Used fallback columns"
+    return "No usable prices"
+
+
+def _prepare_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+
+def run(config: Config) -> int:
+    LOGGER.info("Starting cost estimate generation")
+    config.ensure_output_dirs()
+
+    api_key = read_api_key(config)
+    ai_helper = AIHelper(api_key=api_key, disabled=config.disable_ai)
+
+    sources: List[SourceEntry] = io.load_historical_sources(
+        config.payitems_workbook, config.input_payitems
+    )
+    mapper = PayItemMapper(sources)
+
+    estimate_audit_df = io.read_estimate_audit_csv(config.estimate_audit_csv)
+    item_codes = _collect_item_codes(estimate_audit_df)
+
+    try:
+        estimate_sheet_df = io.read_estimate_sheet(config.estimate_xlsx)
+        item_codes.update(_collect_item_codes(estimate_sheet_df))
+    except FileNotFoundError:
+        LOGGER.warning("Estimate workbook %s not found; continuing without it", config.estimate_xlsx)
+    except Exception as exc:  # pragma: no cover - defensive
+        LOGGER.error("Failed to read estimate workbook: %s", exc)
+
+    stats_by_item: Dict[str, StatsSummary] = {}
+    debug_records: List[Dict[str, object]] = []
+
+    for item_code in sorted(item_codes):
+        match = mapper.match(item_code)
+
+        series_results: List[io.PriceSeriesResult] = []
+        for entry in match.matches:
+            try:
+                result = io.extract_price_series(entry.data)
+            except Exception as exc:  # pragma: no cover - defensive
+                LOGGER.warning("Failed to extract prices from %s: %s", entry.display_name, exc)
+                continue
+            series_results.append(result)
+
+        combined_prices = _combine_price_values(series_results)
+        stats = compute_summary(combined_prices)
+
+        source_names = ", ".join(entry.display_name for entry in match.matches)
+        source_kinds = ", ".join(entry.kind for entry in match.matches)
+        stats.source = source_names
+        stats.notes = _describe_notes(match, series_results)
+        stats.fallback_used = stats.fallback_used or any(result.used_fallback for result in series_results)
+
+        if not combined_prices and match.matches:
+            # No numeric data available despite a match
+            stats.notes = "No usable prices"
+            stats.fallback_used = True
+
+        stats_by_item[normalize_key(item_code)] = stats
+
+        ai_summary = ai_helper.summarize(item_code, _stats_to_dict(stats))
+        record = {
+            "ITEM_CODE": item_code,
+            "NORMALISED_CODE": normalize_key(item_code),
+            "MATCH_STATUS": match.status,
+            "MATCH_SCORE": match.score,
+            "MATCHED_SOURCE_COUNT": len(match.matches),
+            "SOURCE_NAMES": source_names,
+            "SOURCE_KINDS": source_kinds,
+            "DATA_POINTS_USED": stats.data_points,
+            "MEAN_UNIT_PRICE": stats.mean,
+            "STD_DEV": stats.std_dev,
+            "COEF_VAR": stats.coef_var if math.isfinite(stats.coef_var) else "inf",
+            "CONFIDENCE": stats.confidence,
+            "FALLBACK_USED": stats.fallback_used,
+            "NOTES": stats.notes,
+        }
+        if ai_summary:
+            record["AI_SUMMARY"] = ai_summary
+        debug_records.append(record)
+
+    if not config.dry_run:
+        update_estimate_audit(config.estimate_audit_csv, stats_by_item, dry_run=False)
+        update_estimate_draft(config.estimate_xlsx, stats_by_item, dry_run=False)
+        write_mapping_debug(config.mapping_debug_csv, debug_records, dry_run=False)
+    else:
+        update_estimate_audit(config.estimate_audit_csv, stats_by_item, dry_run=True)
+        update_estimate_draft(config.estimate_xlsx, stats_by_item, dry_run=True)
+        write_mapping_debug(config.mapping_debug_csv, debug_records, dry_run=True)
+
+    LOGGER.info("Processing complete for %d items", len(item_codes))
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    _prepare_logging(args.log_level)
+    config = load_config(args)
+    try:
+        return run(config)
+    except Exception as exc:  # pragma: no cover - defensive
+        LOGGER.exception("Pipeline failed: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/CostEstimateGenerator/src/costest/config.py
+++ b/CostEstimateGenerator/src/costest/config.py
@@ -1,0 +1,143 @@
+"""Configuration helpers for the cost estimate generator."""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .sample_data import create_payitems_workbook_from_template
+
+_DEFAULT_BASE = Path(__file__).resolve().parents[2]
+_DEFAULT_DATA = _DEFAULT_BASE / "data_sample"
+_DEFAULT_OUTPUTS = _DEFAULT_BASE / "outputs"
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _default_payitems_dir() -> Path:
+    candidate = _DEFAULT_DATA / "payitems"
+    if candidate.exists():
+        return candidate
+    fallback = _DEFAULT_BASE / "data_in"
+    if fallback.exists():
+        return fallback
+    return candidate
+
+
+def _default_payitems_workbook() -> Path:
+    candidate = _DEFAULT_OUTPUTS / "PayItems_Audit.xlsx"
+    if candidate.exists():
+        return candidate
+
+    template = _DEFAULT_DATA / "payitems_workbook.json"
+    if template.exists():
+        try:
+            create_payitems_workbook_from_template(template, candidate)
+            LOGGER.info("Materialised sample payitems workbook at %s", candidate)
+            return candidate
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            LOGGER.warning("Unable to materialise sample workbook: %s", exc)
+
+    return candidate
+
+
+@dataclass(frozen=True)
+class Config:
+    """Runtime configuration resolved from CLI arguments and environment."""
+
+    input_payitems: Path
+    estimate_audit_csv: Path
+    estimate_xlsx: Path
+    payitems_workbook: Path
+    mapping_debug_csv: Path
+    disable_ai: bool
+    api_key_file: Path
+    dry_run: bool
+
+    @property
+    def base_dir(self) -> Path:
+        return _DEFAULT_BASE
+
+    def ensure_output_dirs(self) -> None:
+        for candidate in (
+            self.estimate_audit_csv.parent,
+            self.estimate_xlsx.parent,
+            self.mapping_debug_csv.parent,
+        ):
+            candidate.mkdir(parents=True, exist_ok=True)
+
+
+def _env_flag(name: str) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return False
+    return value not in {"0", "false", "False", ""}
+
+
+def load_config(args: Optional[object] = None) -> Config:
+    """Create a :class:`Config` from argparse ``args`` and environment."""
+
+    disable_ai = False
+    api_key_file = _DEFAULT_BASE / "API_KEY" / "API_KEY.txt"
+    mapping_debug_csv = _DEFAULT_OUTPUTS / "payitem_mapping_debug.csv"
+
+    if args is not None:
+        def _resolve(value, default):
+            return default if value is None else Path(value)
+
+        input_payitems = _resolve(getattr(args, "input_payitems", None), _default_payitems_dir())
+        estimate_audit_csv = _resolve(
+            getattr(args, "estimate_audit_csv", None), _DEFAULT_OUTPUTS / "Estimate_Audit.csv"
+        )
+        estimate_xlsx = _resolve(
+            getattr(args, "estimate_xlsx", None), _DEFAULT_OUTPUTS / "Estimate_Draft.xlsx"
+        )
+        payitems_workbook = _resolve(
+            getattr(args, "payitems_workbook", None), _default_payitems_workbook()
+        )
+        api_key_file = _resolve(getattr(args, "api_key_file", None), api_key_file)
+        mapping_debug_csv = _resolve(
+            getattr(args, "mapping_debug_csv", None), mapping_debug_csv
+        )
+        disable_ai = getattr(args, "disable_ai", False)
+        dry_run = getattr(args, "dry_run", False)
+    else:
+        input_payitems = _default_payitems_dir()
+        estimate_audit_csv = _DEFAULT_OUTPUTS / "Estimate_Audit.csv"
+        estimate_xlsx = _DEFAULT_OUTPUTS / "Estimate_Draft.xlsx"
+        payitems_workbook = _default_payitems_workbook()
+        dry_run = False
+
+    disable_ai = disable_ai or _env_flag("DISABLE_OPENAI")
+
+    return Config(
+        input_payitems=input_payitems,
+        estimate_audit_csv=estimate_audit_csv,
+        estimate_xlsx=estimate_xlsx,
+        payitems_workbook=payitems_workbook,
+        mapping_debug_csv=mapping_debug_csv,
+        disable_ai=disable_ai,
+        api_key_file=api_key_file,
+        dry_run=dry_run,
+    )
+
+
+def read_api_key(config: Config) -> Optional[str]:
+    """Read an API key from file or environment if available."""
+
+    if config.disable_ai:
+        return None
+
+    env_key = os.getenv("OPENAI_API_KEY")
+    if env_key:
+        return env_key
+
+    try:
+        return config.api_key_file.read_text(encoding="utf-8").strip() or None
+    except FileNotFoundError:
+        return None
+
+
+__all__ = ["Config", "load_config", "read_api_key"]

--- a/CostEstimateGenerator/src/costest/io.py
+++ b/CostEstimateGenerator/src/costest/io.py
@@ -1,0 +1,126 @@
+"""IO helpers for reading Excel and CSV inputs."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import pandas as pd
+
+from .mapping import SourceEntry, normalize_key
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _coerce_path(path: Path) -> Path:
+    if isinstance(path, Path):
+        return path
+    return Path(path)
+
+
+def load_payitems_from_workbook(path: Path) -> List[SourceEntry]:
+    path = _coerce_path(path)
+    if not path.exists():
+        LOGGER.warning("Payitems workbook %s not found", path)
+        return []
+
+    sheets = pd.read_excel(path, sheet_name=None)
+    entries: List[SourceEntry] = []
+    for sheet_name, df in sheets.items():
+        key = normalize_key(sheet_name)
+        entries.append(SourceEntry(key=key, display_name=sheet_name, kind="workbook", data=df))
+    LOGGER.info("Loaded %d payitem sheets from %s", len(entries), path)
+    return entries
+
+
+def load_payitems_from_directory(directory: Path) -> List[SourceEntry]:
+    directory = _coerce_path(directory)
+    if not directory.exists() or not directory.is_dir():
+        LOGGER.warning("Payitems directory %s not found", directory)
+        return []
+
+    entries: List[SourceEntry] = []
+    for csv_path in sorted(directory.glob("*.csv")):
+        try:
+            df = pd.read_csv(csv_path)
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.error("Failed to load %s: %s", csv_path, exc)
+            continue
+        key = normalize_key(csv_path.stem)
+        entries.append(SourceEntry(key=key, display_name=csv_path.name, kind="csv", data=df))
+    LOGGER.info("Loaded %d payitem csv files from %s", len(entries), directory)
+    return entries
+
+
+def load_historical_sources(workbook: Path, directory: Path) -> List[SourceEntry]:
+    sources: List[SourceEntry] = []
+    sources.extend(load_payitems_from_workbook(workbook))
+    sources.extend(load_payitems_from_directory(directory))
+    return sources
+
+
+def read_estimate_audit_csv(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path)
+
+
+def read_estimate_sheet(path: Path, sheet_name: str = "Estimate") -> pd.DataFrame:
+    return pd.read_excel(path, sheet_name=sheet_name)
+
+
+def detect_price_columns(columns: Iterable[str]) -> List[str]:
+    matches: List[str] = []
+    for column in columns:
+        lowered = str(column).lower()
+        if any(keyword in lowered for keyword in ("price", "unit_price", "unit price")):
+            matches.append(column)
+    return matches
+
+
+@dataclass(frozen=True)
+class PriceSeriesResult:
+    """Container describing the extracted numeric price series."""
+
+    values: pd.Series
+    columns_used: List[str]
+    used_fallback: bool
+
+    def has_values(self) -> bool:
+        return not self.values.empty
+
+
+def extract_price_series(df: pd.DataFrame) -> PriceSeriesResult:
+    price_columns = detect_price_columns(df.columns)
+    series = pd.Series(dtype=float)
+    for column in price_columns:
+        numeric = pd.to_numeric(df[column], errors="coerce")
+        series = pd.concat([series, numeric], ignore_index=True)
+    series = series.dropna()
+    if not series.empty:
+        return PriceSeriesResult(series, list(price_columns), used_fallback=False)
+
+    # Fallback to DIST_*/STATE_* columns containing price-like data
+    fallback_cols: List[str] = []
+    for column in df.columns:
+        upper = str(column).upper()
+        if upper.startswith("DIST") or upper.startswith("STATE"):
+            fallback_cols.append(column)
+
+    fallback_series = pd.Series(dtype=float)
+    for column in fallback_cols:
+        numeric = pd.to_numeric(df[column], errors="coerce")
+        fallback_series = pd.concat([fallback_series, numeric], ignore_index=True)
+    fallback_series = fallback_series.dropna()
+    return PriceSeriesResult(fallback_series, fallback_cols, used_fallback=bool(fallback_cols))
+
+
+__all__ = [
+    "load_payitems_from_workbook",
+    "load_payitems_from_directory",
+    "load_historical_sources",
+    "read_estimate_audit_csv",
+    "read_estimate_sheet",
+    "detect_price_columns",
+    "PriceSeriesResult",
+    "extract_price_series",
+]

--- a/CostEstimateGenerator/src/costest/mapping.py
+++ b/CostEstimateGenerator/src/costest/mapping.py
@@ -1,0 +1,102 @@
+"""Mapping helpers between pay item codes and historical sources."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+NORMALIZE_PATTERN = re.compile(r"[^0-9A-Za-z]+")
+
+
+def normalize_key(value: str) -> str:
+    """Normalise item codes and sheet names for matching."""
+
+    if value is None:
+        return ""
+    collapsed = NORMALIZE_PATTERN.sub("", value)
+    return collapsed.upper()
+
+
+@dataclass(frozen=True)
+class SourceEntry:
+    """Represents a historical dataset source (sheet or csv)."""
+
+    key: str
+    display_name: str
+    kind: str
+    data: object
+
+
+@dataclass(frozen=True)
+class MatchResult:
+    """Outcome of attempting to align an item code with known sources."""
+
+    matches: List[SourceEntry]
+    status: str
+    score: int
+
+    @property
+    def primary(self) -> Optional[SourceEntry]:
+        """Return the first matched source, if any."""
+
+        return self.matches[0] if self.matches else None
+
+
+class PayItemMapper:
+    """Best-effort matcher from item codes to available sources."""
+
+    def __init__(self, sources: Iterable[SourceEntry]):
+        self._sources: List[SourceEntry] = list(sources)
+        self._by_key: dict[str, List[SourceEntry]] = {}
+        for entry in self._sources:
+            if not entry.key:
+                continue
+            self._by_key.setdefault(entry.key, []).append(entry)
+
+    def match(self, item_code: str) -> MatchResult:
+        """Return matching sources, status, and score for the provided item."""
+
+        normalised_code = normalize_key(item_code)
+        if not normalised_code:
+            return MatchResult([], "empty", 0)
+
+        if normalised_code in self._by_key:
+            return MatchResult(list(self._by_key[normalised_code]), "exact", 3)
+
+        best_keys: List[str] = []
+        best_score = -1
+        for key in self._by_key:
+            score = self._score(key, normalised_code)
+            if score > best_score:
+                best_keys = [key]
+                best_score = score
+            elif score == best_score and score > 0:
+                best_keys.append(key)
+
+        if best_score <= 0:
+            return MatchResult([], "unmatched", 0)
+
+        matches: List[SourceEntry] = []
+        seen: set[int] = set()
+        for key in best_keys:
+            for entry in self._by_key.get(key, []):
+                if id(entry) in seen:
+                    continue
+                seen.add(id(entry))
+                matches.append(entry)
+        return MatchResult(matches, "fuzzy", best_score)
+
+    @staticmethod
+    def _score(source_key: str, target_key: str) -> int:
+        if not source_key or not target_key:
+            return -1
+        if source_key == target_key:
+            return 3
+        if source_key.startswith(target_key) or target_key.startswith(source_key):
+            return 2
+        if target_key in source_key or source_key in target_key:
+            return 1
+        return -1
+
+
+__all__ = ["normalize_key", "SourceEntry", "MatchResult", "PayItemMapper"]

--- a/CostEstimateGenerator/src/costest/sample_data.py
+++ b/CostEstimateGenerator/src/costest/sample_data.py
@@ -1,0 +1,71 @@
+"""Helpers for generating sample workbooks from text templates."""
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+from openpyxl import Workbook
+
+DATA_SAMPLE_DIR = Path(__file__).resolve().parents[2] / "data_sample"
+
+
+def _ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_template_rows(csv_path: Path) -> List[List[str]]:
+    with open(csv_path, newline="", encoding="utf-8") as handle:
+        reader = csv.reader(handle)
+        return [row for row in reader]
+
+
+def create_estimate_workbook_from_template(template_csv: Path, destination: Path) -> Path:
+    rows = load_template_rows(template_csv)
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "Estimate"
+    for row in rows:
+        sheet.append(row)
+    _ensure_parent(destination)
+    workbook.save(destination)
+    workbook.close()
+    return destination
+
+
+def _iter_workbook_templates(template_json: Path) -> Iterable[tuple[str, Dict[str, Sequence[object]]]]:
+    with open(template_json, encoding="utf-8") as handle:
+        data = json.load(handle)
+    for sheet_name, payload in data.items():
+        columns = payload.get("columns", [])
+        rows = payload.get("rows", [])
+        yield sheet_name, {"columns": columns, "rows": rows}
+
+
+def create_payitems_workbook_from_template(template_json: Path, destination: Path) -> Path:
+    workbook = Workbook()
+    first = True
+    for sheet_name, payload in _iter_workbook_templates(template_json):
+        if first:
+            sheet = workbook.active
+            sheet.title = sheet_name
+            first = False
+        else:
+            sheet = workbook.create_sheet(title=sheet_name)
+        sheet.append(list(payload["columns"]))
+        for row in payload["rows"]:
+            values = list(row)
+            sheet.append([value if value is not None else "" for value in values])
+    _ensure_parent(destination)
+    workbook.save(destination)
+    workbook.close()
+    return destination
+
+
+__all__ = [
+    "DATA_SAMPLE_DIR",
+    "create_estimate_workbook_from_template",
+    "create_payitems_workbook_from_template",
+    "load_template_rows",
+]

--- a/CostEstimateGenerator/src/costest/stats.py
+++ b/CostEstimateGenerator/src/costest/stats.py
@@ -1,0 +1,114 @@
+"""Statistical helpers for cost estimate generation."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+
+MEAN_FLOOR = 1e-6
+
+
+@dataclass
+class StatsSummary:
+    """Represents computed statistics for a single pay item."""
+
+    data_points: int
+    mean: float
+    std_dev: float
+    coef_var: float
+    confidence: float
+    source: str = ""
+    notes: str = ""
+    fallback_used: bool = False
+
+    @property
+    def std_for_display(self) -> str:
+        if self.data_points == 0:
+            return "N/A"
+        return f"{self.std_dev:.2f}"
+
+    @property
+    def cv_for_display(self) -> str:
+        if not math.isfinite(self.coef_var):
+            return "N/A"
+        return f"{self.coef_var:.4f}"
+
+
+def to_float_sequence(values: Iterable[float]) -> Sequence[float]:
+    cleaned = []
+    for value in values:
+        if value is None:
+            continue
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isnan(number):
+            continue
+        cleaned.append(number)
+    return cleaned
+
+
+def mean(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return float(np.mean(values))
+
+
+def std_dev(values: Sequence[float]) -> float:
+    n = len(values)
+    if n <= 1:
+        return 0.0
+    return float(np.std(values, ddof=1))
+
+
+def coefficient_of_variation(mean_value: float, std_value: float) -> float:
+    mean_floor = max(abs(mean_value), MEAN_FLOOR)
+    return float(std_value) / mean_floor
+
+
+def confidence_score(data_points: int, coef_var: float) -> float:
+    if data_points <= 0 or not math.isfinite(coef_var):
+        return 0.0
+    return (1.0 - math.exp(-data_points / 30.0)) * (1.0 / (1.0 + coef_var))
+
+
+def compute_summary(values: Iterable[float]) -> StatsSummary:
+    numeric_values = to_float_sequence(values)
+    count = len(numeric_values)
+    if count == 0:
+        return StatsSummary(
+            data_points=0,
+            mean=0.0,
+            std_dev=0.0,
+            coef_var=math.inf,
+            confidence=0.0,
+            notes="No historical data",
+            fallback_used=True,
+        )
+
+    avg = mean(numeric_values)
+    stdev = std_dev(numeric_values)
+    cv = coefficient_of_variation(avg, stdev)
+    conf = confidence_score(count, cv)
+    return StatsSummary(
+        data_points=count,
+        mean=avg,
+        std_dev=stdev,
+        coef_var=cv,
+        confidence=conf,
+    )
+
+
+__all__ = [
+    "StatsSummary",
+    "MEAN_FLOOR",
+    "to_float_sequence",
+    "mean",
+    "std_dev",
+    "coefficient_of_variation",
+    "confidence_score",
+    "compute_summary",
+]

--- a/CostEstimateGenerator/src/costest/writer.py
+++ b/CostEstimateGenerator/src/costest/writer.py
@@ -1,0 +1,159 @@
+"""Writers that update Estimate outputs in-place."""
+from __future__ import annotations
+
+import logging
+import math
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+import pandas as pd
+from openpyxl import load_workbook
+
+from .mapping import normalize_key
+from .stats import StatsSummary
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _find_item_code_column(df: pd.DataFrame) -> str:
+    for column in df.columns:
+        lowered = str(column).lower()
+        if "item" in lowered and "code" in lowered:
+            return column
+    raise KeyError("Could not identify ITEM_CODE column in Estimate_Audit.csv")
+
+
+def _ensure_columns(df: pd.DataFrame, after: str, new_columns: Iterable[str]) -> pd.DataFrame:
+    columns = list(df.columns)
+    for column in new_columns:
+        if column not in columns:
+            df[column] = ""
+            columns.append(column)
+    # Reorder columns
+    for column in new_columns:
+        if column in columns:
+            columns.remove(column)
+    if after not in columns:
+        raise KeyError(f"Column {after} not found while updating Estimate_Audit.csv")
+    insert_index = columns.index(after) + 1
+    for offset, column in enumerate(new_columns):
+        columns.insert(insert_index + offset, column)
+    return df.loc[:, columns]
+
+
+def update_estimate_audit(csv_path: Path, stats_by_item: Mapping[str, StatsSummary], dry_run: bool = False) -> None:
+    df = pd.read_csv(csv_path)
+    item_column = _find_item_code_column(df)
+    df = _ensure_columns(df, "DATA_POINTS_USED", ["STD_DEV", "COEF_VAR"])
+
+    for idx, row in df.iterrows():
+        item_code = str(row[item_column])
+        stats = stats_by_item.get(normalize_key(item_code))
+        if not stats:
+            stats = StatsSummary(0, 0.0, 0.0, math.inf, 0.0, notes="No history", fallback_used=True)
+        df.at[idx, "DATA_POINTS_USED"] = int(stats.data_points)
+        if stats.data_points:
+            df.at[idx, "MEAN_UNIT_PRICE"] = round(stats.mean, 2)
+
+        if stats.data_points == 0:
+            df.at[idx, "STD_DEV"] = "N/A"
+            df.at[idx, "COEF_VAR"] = "N/A"
+        else:
+            df.at[idx, "STD_DEV"] = round(stats.std_dev, 2)
+            df.at[idx, "COEF_VAR"] = (
+                round(stats.coef_var, 4) if math.isfinite(stats.coef_var) else "N/A"
+            )
+
+    if dry_run:
+        LOGGER.info("Dry-run enabled; Estimate_Audit.csv not written.")
+        return
+
+    tmp = tempfile.NamedTemporaryFile("w", delete=False, suffix=".csv", newline="")
+    try:
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(tmp.name, index=False)
+        tmp.close()
+        shutil.move(tmp.name, csv_path)
+    finally:
+        Path(tmp.name).unlink(missing_ok=True)
+
+    LOGGER.info("Updated %s", csv_path)
+
+
+def update_estimate_draft(xlsx_path: Path, stats_by_item: Mapping[str, StatsSummary], dry_run: bool = False) -> None:
+    wb = load_workbook(xlsx_path)
+    if "Estimate" not in wb.sheetnames:
+        raise KeyError("Expected 'Estimate' sheet in Estimate_Draft workbook")
+    ws = wb["Estimate"]
+
+    headers = [cell.value if cell.value is not None else "" for cell in ws[1]]
+
+    def find_header(target: str) -> int:
+        for idx, header in enumerate(headers, start=1):
+            if isinstance(header, str) and header.strip().lower() == target.lower():
+                return idx
+        raise KeyError(f"Column {target} not found in Estimate sheet")
+
+    item_col_idx = find_header("ITEM_CODE")
+    data_points_idx = find_header("DATA_POINTS_USED")
+    mean_idx = find_header("MEAN_UNIT_PRICE")
+
+    try:
+        confidence_idx = find_header("CONFIDENCE")
+    except KeyError:
+        ws.insert_cols(data_points_idx + 1)
+        ws.cell(row=1, column=data_points_idx + 1, value="CONFIDENCE")
+        headers.insert(data_points_idx, "CONFIDENCE")
+        confidence_idx = data_points_idx + 1
+        # Indices after insertion shift for columns to the right
+        if mean_idx >= confidence_idx:
+            mean_idx += 1
+
+    for row_idx in range(2, ws.max_row + 1):
+        item_code = ws.cell(row=row_idx, column=item_col_idx).value
+        if item_code is None:
+            continue
+        stats = stats_by_item.get(normalize_key(str(item_code)))
+        if not stats:
+            stats = StatsSummary(0, 0.0, 0.0, math.inf, 0.0, notes="No history", fallback_used=True)
+        ws.cell(row=row_idx, column=data_points_idx, value=int(stats.data_points))
+        if stats.data_points:
+            ws.cell(row=row_idx, column=mean_idx, value=float(round(stats.mean, 2)))
+        ws.cell(row=row_idx, column=confidence_idx, value=float(round(stats.confidence, 4)))
+
+    if dry_run:
+        LOGGER.info("Dry-run enabled; Estimate_Draft.xlsx not written.")
+        wb.close()
+        return
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".xlsx")
+    try:
+        xlsx_path.parent.mkdir(parents=True, exist_ok=True)
+        wb.save(tmp.name)
+        wb.close()
+        tmp.close()
+        shutil.move(tmp.name, xlsx_path)
+    finally:
+        Path(tmp.name).unlink(missing_ok=True)
+
+    LOGGER.info("Updated %s", xlsx_path)
+
+
+def write_mapping_debug(csv_path: Path, records: Iterable[Dict[str, object]], dry_run: bool = False) -> None:
+    if dry_run:
+        LOGGER.info("Dry-run enabled; mapping debug file not written.")
+        return
+
+    df = pd.DataFrame(list(records))
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(csv_path, index=False)
+    LOGGER.info("Wrote mapping debug report to %s", csv_path)
+
+
+__all__ = [
+    "update_estimate_audit",
+    "update_estimate_draft",
+    "write_mapping_debug",
+]

--- a/CostEstimateGenerator/tests/conftest.py
+++ b/CostEstimateGenerator/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the src directory is importable without requiring installation.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))

--- a/CostEstimateGenerator/tests/test_io.py
+++ b/CostEstimateGenerator/tests/test_io.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from costest.io import extract_price_series
+
+
+def test_extract_price_series_prefers_explicit_price_columns():
+    df = pd.DataFrame(
+        {
+            "Unit Price": [10, 12, None],
+            "DIST_AVG": [9, 11, 10],
+        }
+    )
+    result = extract_price_series(df)
+    assert result.used_fallback is False
+    assert result.columns_used == ["Unit Price"]
+    assert result.values.tolist() == [10.0, 12.0]
+
+
+def test_extract_price_series_uses_fallback_when_needed():
+    df = pd.DataFrame(
+        {
+            "Unit Price": [None, None],
+            "DIST_PRICE": [8, 9],
+        }
+    )
+    result = extract_price_series(df)
+    assert result.used_fallback is True
+    assert result.columns_used == ["DIST_PRICE"]
+    assert result.values.tolist() == [8.0, 9.0]
+
+
+def test_extract_price_series_handles_empty_fallback():
+    df = pd.DataFrame(
+        {
+            "DIST_A": ["bad", None],
+            "STATE_B": [None, ""],
+        }
+    )
+    result = extract_price_series(df)
+    assert result.used_fallback is True
+    assert result.values.tolist() == []

--- a/CostEstimateGenerator/tests/test_mapping.py
+++ b/CostEstimateGenerator/tests/test_mapping.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from costest.mapping import MatchResult, PayItemMapper, SourceEntry, normalize_key
+
+
+def test_normalize_key_strips_non_alphanumeric():
+    assert normalize_key("Item 001 - Concrete") == "ITEM001CONCRETE"
+    assert normalize_key(" item\t002 ") == "ITEM002"
+
+
+def test_mapper_prefers_exact_match():
+    sources = [
+        SourceEntry(key=normalize_key("Item001"), display_name="Item001", kind="workbook", data=None),
+        SourceEntry(key=normalize_key("Item004History"), display_name="Item004 History", kind="workbook", data=None),
+    ]
+    mapper = PayItemMapper(sources)
+    result = mapper.match("ITEM-001")
+    assert isinstance(result, MatchResult)
+    assert result.status == "exact"
+    assert result.score == 3
+    assert result.primary is sources[0]
+    assert [entry.display_name for entry in result.matches] == ["Item001"]
+
+
+def test_mapper_fuzzy_match_when_no_exact():
+    sources = [
+        SourceEntry(key=normalize_key("ITEM004HISTORY"), display_name="Item004 History", kind="workbook", data=None),
+        SourceEntry(key=normalize_key("OTHER"), display_name="Other", kind="csv", data=None),
+    ]
+    mapper = PayItemMapper(sources)
+    result = mapper.match("ITEM 004")
+    assert result.status == "fuzzy"
+    assert result.score >= 1
+    assert result.primary is sources[0]
+
+
+def test_mapper_returns_none_for_unknown():
+    mapper = PayItemMapper([])
+    result = mapper.match("UNKNOWN")
+    assert result.matches == []
+    assert result.status == "unmatched"
+    assert result.score == 0
+
+
+def test_mapper_returns_all_exact_matches():
+    sources = [
+        SourceEntry(key=normalize_key("Item001"), display_name="Item001 sheet", kind="workbook", data=None),
+        SourceEntry(key=normalize_key("Item001"), display_name="item001.csv", kind="csv", data=None),
+        SourceEntry(key=normalize_key("Other"), display_name="Other", kind="csv", data=None),
+    ]
+    mapper = PayItemMapper(sources)
+    result = mapper.match("Item 001")
+    assert result.status == "exact"
+    assert result.score == 3
+    assert len(result.matches) == 2
+    assert {entry.display_name for entry in result.matches} == {"Item001 sheet", "item001.csv"}

--- a/CostEstimateGenerator/tests/test_stats.py
+++ b/CostEstimateGenerator/tests/test_stats.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import math
+
+from costest import stats
+
+
+def test_compute_summary_basic():
+    summary = stats.compute_summary([100, 110, 105])
+    assert summary.data_points == 3
+    assert math.isclose(summary.mean, 105.0, rel_tol=1e-6)
+    assert math.isclose(summary.std_dev, 5.0, rel_tol=1e-6)
+    assert math.isclose(summary.coef_var, 5.0 / 105.0, rel_tol=1e-6)
+    expected_conf = (1 - math.exp(-3 / 30.0)) * (1 / (1 + (5.0 / 105.0)))
+    assert math.isclose(summary.confidence, expected_conf, rel_tol=1e-6)
+
+
+def test_coefficient_of_variation_uses_floor():
+    cv = stats.coefficient_of_variation(0.0, 2.0)
+    assert math.isclose(cv, 2.0 / stats.MEAN_FLOOR)
+
+
+def test_confidence_zero_points():
+    assert stats.confidence_score(0, 1.0) == 0.0
+
+
+def test_summary_no_values():
+    summary = stats.compute_summary([])
+    assert summary.data_points == 0
+    assert summary.confidence == 0.0
+    assert summary.fallback_used is True
+    assert summary.cv_for_display == "N/A"

--- a/CostEstimateGenerator/tests/test_writer.py
+++ b/CostEstimateGenerator/tests/test_writer.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from openpyxl import load_workbook
+
+from costest.cli import run
+from costest.config import load_config
+from costest.sample_data import (
+    DATA_SAMPLE_DIR,
+    create_estimate_workbook_from_template,
+    create_payitems_workbook_from_template,
+)
+
+
+DATA_DIR = DATA_SAMPLE_DIR
+
+
+def _read_excel_rows(path: Path) -> list[list[object]]:
+    wb = load_workbook(path)
+    ws = wb["Estimate"]
+    data = [list(row) for row in ws.iter_rows(values_only=True)]
+    wb.close()
+    return data
+
+
+def test_pipeline_updates_outputs(tmp_path):
+    outputs = tmp_path / "outputs"
+    outputs.mkdir()
+
+    shutil.copy(DATA_DIR / "Estimate_Audit.csv", outputs / "Estimate_Audit.csv")
+    create_estimate_workbook_from_template(
+        DATA_DIR / "Estimate_Draft_template.csv", outputs / "Estimate_Draft.xlsx"
+    )
+
+    payitems_workbook = tmp_path / "PayItems_Audit.xlsx"
+    create_payitems_workbook_from_template(
+        DATA_DIR / "payitems_workbook.json", payitems_workbook
+    )
+
+    args = SimpleNamespace(
+        input_payitems=DATA_DIR / "payitems",
+        estimate_audit_csv=outputs / "Estimate_Audit.csv",
+        estimate_xlsx=outputs / "Estimate_Draft.xlsx",
+        payitems_workbook=payitems_workbook,
+        mapping_debug_csv=outputs / "payitem_mapping_debug.csv",
+        disable_ai=True,
+        api_key_file=None,
+        dry_run=False,
+        log_level="INFO",
+    )
+    config = load_config(args)
+
+    first_run_status = run(config)
+    assert first_run_status == 0
+
+    audit_df = pd.read_csv(outputs / "Estimate_Audit.csv")
+    assert "STD_DEV" in audit_df.columns
+    assert "COEF_VAR" in audit_df.columns
+    data_points_idx = list(audit_df.columns).index("DATA_POINTS_USED")
+    assert audit_df.columns[data_points_idx + 1] == "STD_DEV"
+    assert audit_df.columns[data_points_idx + 2] == "COEF_VAR"
+    numeric_std = pd.to_numeric(audit_df["STD_DEV"], errors="coerce")
+    assert numeric_std.notna().sum() >= 2
+
+    row_item1 = audit_df.loc[audit_df["ITEM_CODE"] == "ITEM-001"].iloc[0]
+    assert row_item1["DATA_POINTS_USED"] == 3
+    assert float(row_item1["MEAN_UNIT_PRICE"]) == pytest.approx(105.0, rel=1e-6)
+    std_item1 = pd.to_numeric([row_item1["STD_DEV"]], errors="coerce").item()
+    assert std_item1 == pytest.approx(5.0, rel=1e-6)
+    coef_item1 = pd.to_numeric([row_item1["COEF_VAR"]], errors="coerce").item()
+    assert coef_item1 == pytest.approx(5.0 / 105.0, rel=1e-3)
+
+    row_item4 = audit_df.loc[audit_df["ITEM_CODE"] == "Item004"].iloc[0]
+    assert float(row_item4["MEAN_UNIT_PRICE"]) == pytest.approx(77.75, rel=1e-6)
+    assert pd.to_numeric([row_item4["STD_DEV"]], errors="coerce").item() == pytest.approx(3.86, rel=1e-2)
+    assert pd.to_numeric([row_item4["COEF_VAR"]], errors="coerce").item() == pytest.approx(0.0497, rel=1e-3)
+
+    row_missing = audit_df.loc[audit_df["ITEM_CODE"] == "ITEM005"].iloc[0]
+    assert row_missing["STD_DEV"] == "N/A"
+    assert row_missing["COEF_VAR"] == "N/A"
+
+    excel_rows = _read_excel_rows(outputs / "Estimate_Draft.xlsx")
+    headers = excel_rows[0]
+    data_points_pos = headers.index("DATA_POINTS_USED")
+    assert headers[data_points_pos + 1] == "CONFIDENCE"
+    confidence_values = [row[data_points_pos + 1] for row in excel_rows[1:]]
+    for value in confidence_values:
+        if value is None:
+            continue
+        assert 0.0 <= value <= 1.0
+
+    debug_path = outputs / "payitem_mapping_debug.csv"
+    assert debug_path.exists()
+    debug_df = pd.read_csv(debug_path)
+    assert set(["ITEM_CODE", "MATCH_STATUS", "SOURCE_NAMES"]).issubset(debug_df.columns)
+    assert {"SOURCE_KINDS", "MATCHED_SOURCE_COUNT", "FALLBACK_USED"}.issubset(debug_df.columns)
+    assert (debug_df["CONFIDENCE"] <= 1.0).all()
+    assert (debug_df["MATCHED_SOURCE_COUNT"] >= 0).all()
+
+    audit_df_first = audit_df.copy()
+    excel_rows_first = excel_rows
+
+    second_run_status = run(config)
+    assert second_run_status == 0
+
+    audit_df_second = pd.read_csv(outputs / "Estimate_Audit.csv")
+    pd.testing.assert_frame_equal(audit_df_first, audit_df_second)
+
+    excel_rows_second = _read_excel_rows(outputs / "Estimate_Draft.xlsx")
+    assert excel_rows_first == excel_rows_second


### PR DESCRIPTION
## Summary
- enhance the CostEstimateGenerator pipeline to aggregate all matched historical sources and capture richer mapping metadata
- add metadata-aware price extraction, numeric output formatting, and smarter default input resolution
- expand tests and docs to cover fallback handling, multi-source matches, and updated behavior
- replace binary sample workbooks with text-based templates and a generator script to satisfy repository PR checks

## Testing
- python -m pytest -q *(fails locally: missing numpy/pandas dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d400ba29b8832a829fba502ee5b2cb